### PR TITLE
Fix KeyError and show toolbar labels

### DIFF
--- a/japan_niche/data.py
+++ b/japan_niche/data.py
@@ -24,9 +24,49 @@ def load_data():
     if not os.path.exists(DATA_FILE):
         return {"cards": {}, "study_deck": [], "last_session": None}
     with open(DATA_FILE, 'r', encoding='utf-8') as f:
-        return json.load(f)
+        data = json.load(f)
+    if _upgrade_data_format(data):
+        save_data(data)
+    return data
 
 
 def save_data(data):
     with open(DATA_FILE, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=4)
+
+
+def _upgrade_data_format(data):
+    """Migrate cards from the old 'front/back' format to the new fields."""
+    changed = False
+    cards = data.get('cards', {})
+    for card in cards.values():
+        if 'jp' in card and 'en' in card:
+            continue
+        # Extract details from the card id and back text
+        parts = card.get('id', '').split('|')
+        if len(parts) >= 5:
+            jp = parts[2]
+            en = parts[3]
+            direction = parts[4]
+        else:
+            continue
+        back = card.get('back', '')
+        import re
+        m = re.match(r"(.+?)\s*\[(.+?)\]\s*\[(.+?)\]", back)
+        if not m:
+            continue
+        val1, pron, hira = m.groups()
+        if direction == 'J2E':
+            en = val1
+        else:
+            jp = val1
+        card.update({
+            'jp': jp,
+            'en': en,
+            'pron': pron,
+            'hira': hira,
+            'direction': direction,
+            'front': jp if direction == 'J2E' else en,
+        })
+        changed = True
+    return changed

--- a/japan_niche/gui.py
+++ b/japan_niche/gui.py
@@ -127,11 +127,15 @@ class StudyWidget(QWidget):
 
     def show_answer(self):
         c = self.card
-        self.orig_label.setText(c['jp'])
-        self.desc_label.setText(c['en'])
-        self.pron_label.setText(c['pron'])
-        self.jp_label.setText(c['hira'])
-        self.jp_pron_label.setText(c['pron'].replace('-', ' '))
+        jp = c.get('jp', c.get('front', ''))
+        en = c.get('en', c.get('back', ''))
+        pron = c.get('pron', '')
+        hira = c.get('hira', '')
+        self.orig_label.setText(jp)
+        self.desc_label.setText(en)
+        self.pron_label.setText(pron)
+        self.jp_label.setText(hira)
+        self.jp_pron_label.setText(pron.replace('-', ' '))
         self.status_label.setText(f"Score: {c['skill']}  Struggle: {c['struggle']}")
         self.show_btn.setEnabled(False)
         for btn in (
@@ -192,6 +196,7 @@ class MainWindow(QWidget):
             btn = QToolButton()
             btn.setText(text)
             btn.setIcon(self.style().standardIcon(icon))
+            btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
             btn.clicked.connect(slot)
             toolbar.addWidget(btn)
             return btn


### PR DESCRIPTION
## Summary
- add `_upgrade_data_format` to migrate old flashcard data
- handle missing fields in `show_answer`
- display text beside toolbar icons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850f18b7e04832582fd5067f1550dba