### PR TITLE
Fix duplicate line and button alignment in study view

### DIFF
--- a/japan_niche/gui.py
+++ b/japan_niche/gui.py
@@ -102,6 +102,7 @@ class StudyWidget(QWidget):
         layout.addWidget(self.pron_label)
         layout.addWidget(self.jp_label)
         layout.addWidget(self.hira_container)
+        layout.addStretch()
         layout.addWidget(self.show_btn)
         layout.addLayout(rating_layout)
         layout.addWidget(self.status_label)
@@ -176,7 +177,7 @@ class StudyWidget(QWidget):
 
         if direction == 'E2J':
             answer = jp
-            extra = en
+            extra = ''
         else:
             answer = en
             extra = ''


### PR DESCRIPTION
## Summary
- remove redundant English line when front card is English
- keep action buttons aligned to the bottom of the study view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68517d85b0208325a2e484bc585f3b92