### PR TITLE
Adjust reveal line spacing

### DIFF
--- a/japan_niche/gui.py
+++ b/japan_niche/gui.py
@@ -98,7 +98,9 @@ class StudyWidget(QWidget):
 
         layout = QVBoxLayout()
         layout.addWidget(self.front_label)
+        layout.addSpacing(16)
         layout.addWidget(self.desc_label)
+        layout.addSpacing(16)
         layout.addWidget(self.pron_label)
         layout.addWidget(self.jp_label)
         layout.addWidget(self.hira_container)


### PR DESCRIPTION
## Summary
- move extra spacing to between the front and description labels

## Testing
- `python -m py_compile japan_niche/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68517f067a9083259f265281a5688cfb