### PR TITLE
Unify flashcard storage format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ python main.py
 3. Click the icons along the top of the window to **Study**, **Scan Files**, start a **New Day**, or **Quit** the program.
 4. During study, press **Space** to reveal the answer and **A**, **S**, **D**, or **F** to grade the card.
 
-Progress is stored in `flashcard_data.json`. To reset all progress, run:
+Progress is stored in `flashcard_data.json`. Older data files can be
+converted to the new unified format by running:
+
+```bash
+python convert_flashcard_data.py
+```
+
+To reset all progress, run:
 
 ```bash
 python reset_flashcards.py

--- a/convert_flashcard_data.py
+++ b/convert_flashcard_data.py
@@ -1,0 +1,86 @@
+import json
+import os
+
+DATA_FILE = 'flashcard_data.json'
+
+
+def convert():
+    if not os.path.exists(DATA_FILE):
+        print('flashcard_data.json not found')
+        return
+
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    # Detect already converted format
+    sample = next(iter(data.get('cards', {}).values()), None)
+    if sample and isinstance(sample.get('ratings'), dict):
+        print('Data already in new format')
+        return
+
+    old_cards = data.get('cards', {})
+    new_cards = {}
+    pair_map = {}
+    id_map = {}
+
+    for cid, card in old_cards.items():
+        jp = card.get('jp')
+        en = card.get('en')
+        pron = card.get('pron')
+        hira = card.get('hira')
+        direction = card.get('direction', 'J2E')
+        base_key = f"{jp}|{en}"
+        lst = pair_map.setdefault(base_key, [])
+
+        target = None
+        for c in lst:
+            if not c['ratings'][direction]:
+                target = c
+                break
+        if target is None:
+            idx = len(lst)
+            new_id = base_key + ('*' * idx if idx else '')
+            target = {
+                'id': new_id,
+                'jp': jp,
+                'en': en,
+                'pron': pron,
+                'hira': hira,
+                'deck': card.get('deck', 'no_deck'),
+                'ratings': {'J2E': [], 'E2J': []},
+                'skill': {'J2E': 0, 'E2J': 0},
+                'struggle': {'J2E': 0, 'E2J': 0},
+                'last_study': {'J2E': None, 'E2J': None},
+            }
+            lst.append(target)
+            new_cards[new_id] = target
+        target['ratings'][direction] = card.get('ratings', [])
+        target['skill'][direction] = card.get('skill', 0)
+        target['struggle'][direction] = card.get('struggle', 0)
+        target['last_study'][direction] = card.get('last_study')
+        if card.get('deck', 'no_deck') != 'no_deck':
+            target['deck'] = card['deck']
+        id_map[cid] = target['id']
+
+    new_study_deck = []
+    for cid in data.get('study_deck', []):
+        nid = id_map.get(cid)
+        if nid and nid not in new_study_deck:
+            new_study_deck.append(nid)
+
+    new_data = {
+        'cards': new_cards,
+        'study_deck': new_study_deck,
+        'last_session': data.get('last_session'),
+    }
+
+    backup = DATA_FILE + '.bak'
+    os.rename(DATA_FILE, backup)
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(new_data, f, indent=4)
+    print(f'Converted {len(old_cards)} cards to {len(new_cards)} cards.')
+    print(f'Backup created at {backup}')
+
+
+if __name__ == '__main__':
+    convert()

--- a/japan_niche/cards.py
+++ b/japan_niche/cards.py
@@ -7,11 +7,21 @@ FLASHCARD_DIR = 'flashcards'
 SCORE_MAP = {'A': -2, 'S': -1, 'D': 1, 'F': 2}
 
 
-def parse_markdown_files():
+def parse_markdown_files(existing_ids=None):
+    """Parse markdown files into card objects.
+
+    Parameters
+    ----------
+    existing_ids : Iterable[str], optional
+        Set of ids that already exist in the data file so we can avoid
+        collisions when generating ids for duplicate cards.
+    """
+    if existing_ids is None:
+        existing_ids = set()
     cards = {}
     if not os.path.isdir(FLASHCARD_DIR):
         return cards
-    current_cat = ''
+
     entry_re = re.compile(r'-\s*(.+?):\s*(.+?)\s*\[(.+?)\]\s*\[(.+?)\]')
     for fname in os.listdir(FLASHCARD_DIR):
         if not fname.endswith('.md'):
@@ -20,49 +30,59 @@ def parse_markdown_files():
             for line in f:
                 line = line.strip()
                 if line.startswith('#'):
-                    current_cat = line[1:].strip()
-                elif line.startswith('-'):
+                    # category headers are ignored in the new format
+                    continue
+                if line.startswith('-'):
                     m = entry_re.match(line)
-                    if m:
-                        jp, en, pron, hira = m.groups()
-                        base_id = f"{fname}|{current_cat}|{jp}|{en}"
-                        common = {
-                            'jp': jp,
-                            'en': en,
-                            'pron': pron,
-                            'hira': hira,
-                            'category': current_cat,
-                            'deck': 'no_deck',
-                            'ratings': [],
-                            'skill': 0,
-                            'struggle': 0,
-                            'last_study': None,
-                        }
-                        card_j2e = common.copy()
-                        card_j2e.update({'id': base_id + '|J2E', 'front': jp, 'direction': 'J2E'})
-                        card_e2j = common.copy()
-                        card_e2j.update({'id': base_id + '|E2J', 'front': en, 'direction': 'E2J'})
-                        cards[card_j2e['id']] = card_j2e
-                        cards[card_e2j['id']] = card_e2j
+                    if not m:
+                        continue
+                    jp, en, pron, hira = m.groups()
+                    base_id = f"{jp}|{en}"
+                    cid = base_id
+                    while cid in existing_ids or cid in cards:
+                        cid += '*'
+
+                    cards[cid] = {
+                        'id': cid,
+                        'jp': jp,
+                        'en': en,
+                        'pron': pron,
+                        'hira': hira,
+                        'deck': 'no_deck',
+                        'ratings': {'J2E': [], 'E2J': []},
+                        'skill': {'J2E': 0, 'E2J': 0},
+                        'struggle': {'J2E': 0, 'E2J': 0},
+                        'last_study': {'J2E': None, 'E2J': None},
+                    }
     return cards
 
 
 def scan_files(data):
-    new_cards = parse_markdown_files()
+    """Read markdown files and merge cards into *data*."""
+    new_cards = parse_markdown_files(existing_ids=set(data['cards'].keys()))
     for cid, card in new_cards.items():
         if cid not in data['cards']:
             data['cards'][cid] = card
         else:
             existing = data['cards'][cid]
-            for k in ['front', 'jp', 'en', 'pron', 'hira', 'category']:
+            for k in ['jp', 'en', 'pron', 'hira']:
                 existing[k] = card[k]
     save_data(data)
     print(f"Imported {len(new_cards)} cards. Total cards: {len(data['cards'])}")
 
 
+def _total_struggle(card):
+    return card['struggle']['J2E'] + card['struggle']['E2J']
+
+
+def _last_study(card):
+    times = [t for t in card['last_study'].values() if t is not None]
+    return min(times) if times else 0
+
+
 def select_review_cards(data, count):
     review = [c for c in data['cards'].values() if c['deck'] == 'review']
-    review.sort(key=lambda c: (-c['struggle'], c['last_study'] or 0))
+    review.sort(key=lambda c: (-_total_struggle(c), _last_study(c)))
     return [c['id'] for c in review[:count]]
 
 
@@ -74,22 +94,22 @@ def select_new_cards(data, count):
 def start_new_day(data, config):
     for cid in list(data['study_deck']):
         card = data['cards'][cid]
-        card['ratings'] = []
-        card['skill'] = 0
-        card['struggle'] = 0
+        card['ratings'] = {'J2E': [], 'E2J': []}
+        card['skill'] = {'J2E': 0, 'E2J': 0}
+        card['struggle'] = {'J2E': 0, 'E2J': 0}
     for cid in select_new_cards(data, config['new_cards']):
         card = data['cards'][cid]
         card['deck'] = 'study'
-        card['ratings'] = []
-        card['skill'] = 0
-        card['struggle'] = 0
+        card['ratings'] = {'J2E': [], 'E2J': []}
+        card['skill'] = {'J2E': 0, 'E2J': 0}
+        card['struggle'] = {'J2E': 0, 'E2J': 0}
         data['study_deck'].append(cid)
     for cid in select_review_cards(data, config['review_cards']):
         card = data['cards'][cid]
         card['deck'] = 'study'
-        card['ratings'] = []
-        card['skill'] = 0
-        card['struggle'] = 0
+        card['ratings'] = {'J2E': [], 'E2J': []}
+        card['skill'] = {'J2E': 0, 'E2J': 0}
+        card['struggle'] = {'J2E': 0, 'E2J': 0}
         data['study_deck'].append(cid)
     data['last_session'] = str(datetime.date.today())
     save_data(data)


### PR DESCRIPTION
## Summary
- store each flash card once with per-direction stats
- update study logic for new format
- support duplicate entries by appending `*` to ids
- add script to convert existing `flashcard_data.json` files
- document conversion script in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685acf0ef93483259faf5d8f664650d3