### PR TITLE
Modify card ID to use Japanese word only

### DIFF
--- a/japan_niche/cards.py
+++ b/japan_niche/cards.py
@@ -37,10 +37,10 @@ def parse_markdown_files(existing_ids=None):
                     if not m:
                         continue
                     jp, en, pron, hira = m.groups()
-                    base_id = f"{jp}|{en}"
-                    cid = base_id
-                    while cid in existing_ids or cid in cards:
-                        cid += '*'
+                    cid = jp
+                    if cid in existing_ids or cid in cards:
+                        print(f"Duplicate card id '{cid}' found in {fname}")
+                        continue
 
                     cards[cid] = {
                         'id': cid,


### PR DESCRIPTION
## Summary
- use the Japanese term itself as the card ID
- warn on duplicates instead of auto‑creating a new ID

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ad4256ef48325b4aa51e383e87f57