### PR TITLE
Fix rating upgrade conversion

### DIFF
--- a/japan_niche/data.py
+++ b/japan_niche/data.py
@@ -40,33 +40,65 @@ def _upgrade_data_format(data):
     changed = False
     cards = data.get('cards', {})
     for card in cards.values():
-        if 'jp' in card and 'en' in card:
-            continue
-        # Extract details from the card id and back text
-        parts = card.get('id', '').split('|')
-        if len(parts) >= 5:
-            jp = parts[2]
-            en = parts[3]
-            direction = parts[4]
-        else:
-            continue
-        back = card.get('back', '')
-        import re
-        m = re.match(r"(.+?)\s*\[(.+?)\]\s*\[(.+?)\]", back)
-        if not m:
-            continue
-        val1, pron, hira = m.groups()
-        if direction == 'J2E':
-            en = val1
-        else:
-            jp = val1
-        card.update({
-            'jp': jp,
-            'en': en,
-            'pron': pron,
-            'hira': hira,
-            'direction': direction,
-            'front': jp if direction == 'J2E' else en,
-        })
-        changed = True
+        # ------------------------------------------------------------------
+        # Convert the original front/back format (pre refactor) to the new
+        # explicit field format (jp/en/pron/hira) used by the GUI.  These old
+        # cards stored all of their information in the ``id`` and ``back``
+        # fields.
+        # ------------------------------------------------------------------
+        if 'jp' not in card or 'en' not in card:
+            parts = card.get('id', '').split('|')
+            if len(parts) >= 5:
+                jp = parts[2]
+                en = parts[3]
+                direction = parts[4]
+            else:
+                continue
+            back = card.get('back', '')
+            import re
+            m = re.match(r"(.+?)\s*\[(.+?)\]\s*\[(.+?)\]", back)
+            if not m:
+                continue
+            val1, pron, hira = m.groups()
+            if direction == 'J2E':
+                en = val1
+            else:
+                jp = val1
+            card.update({
+                'jp': jp,
+                'en': en,
+                'pron': pron,
+                'hira': hira,
+                'direction': direction,
+                'front': jp if direction == 'J2E' else en,
+            })
+            changed = True
+
+        # ------------------------------------------------------------------
+        # Convert rating/skill/struggle fields from a single direction list
+        # into the newer per-direction dictionaries.  Older versions of the
+        # program kept ``ratings`` as a list and ``skill``/``struggle`` as
+        # integers keyed by ``direction``.  The GUI expects dictionaries so
+        # upgrade the structure if necessary.
+        # ------------------------------------------------------------------
+        if not isinstance(card.get('ratings'), dict):
+            direction = card.get('direction', 'J2E')
+            ratings = card.get('ratings', [])
+            skill = card.get('skill', 0)
+            struggle = card.get('struggle', 0)
+            last = card.get('last_study')
+
+            card['ratings'] = {'J2E': [], 'E2J': []}
+            card['ratings'][direction] = ratings
+
+            card['skill'] = {'J2E': 0, 'E2J': 0}
+            card['skill'][direction] = skill
+
+            card['struggle'] = {'J2E': 0, 'E2J': 0}
+            card['struggle'][direction] = struggle
+
+            card['last_study'] = {'J2E': None, 'E2J': None}
+            card['last_study'][direction] = last
+
+            changed = True
     return changed


### PR DESCRIPTION
## Summary
- convert old ratings, skill, and struggle lists in-place when loading data

## Testing
- `python -m py_compile japan_niche/data.py`
- `python -m py_compile japan_niche/gui.py`
- `python -m py_compile japan_niche/cards.py japan_niche/__init__.py main.py convert_flashcard_data.py reset_flashcards.py`

------
https://chatgpt.com/codex/tasks/task_e_685adb2970808325b7b3a5bfb84b531b